### PR TITLE
Chore: added repo infra + support to publish to npmjs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+# Description
+<!--- Describe your changes here -->
+
+# Fixes / Implements
+<!--- Link issue ticket or story here -->
+<!--- For Jira, you can use the [IA-XXXX] shorthand -->
+
+# How Has This Been Tested?
+<!--- Describe the tests you ran to verify things work -->
+<!--- List tests that you have added if the change is for something new -->
+
+# Checklist
+<!--- list of things to check before requesting for review -->
+- [ ] I have performed a self-review of my code
+- [ ] If it is a core feature, I have added thorough tests.
+- [ ] I have tagged @inventive-eng as one of the reviewers

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ SDK library for types, function calls and React components to embed Inventive co
 
 # Getting Started
 
+## Commit message
+
+We use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) to enforce commit message style.
+Here is a [list of rules](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#rules) to follow.
+
+```
+<type>: <short summary>
+  │             │
+  │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
+  │
+  └─⫸ Commit Type: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
+```
+
 ## Manual publish
 1. Make sure you are logged into your npm for `--scope=@inventive`:
     ```bash

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # inventive-sdk
 SDK library for types, function calls and React components to embed Inventive content in any web app
+
+# Getting Started
+
+## Manual publish
+1. Make sure you are logged into your npm for `--scope=@inventive`:
+    ```bash
+    npm login --scope=@inventive
+    ```
+2. Make sure the version number is properly bumped
+3. In the command line, run the following command:
+    ```bash
+    yarn publish:npm
+    ```
+    it will build the package and publish it to the npm registry under the said version number.
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@madeinventive/inventive-sdk",
+  "name": "@inventive/sdk",
   "description": "SDK library for types, function calls and React components to embed Inventive content in any web app",
   "author": "Inventive X",
   "version": "0.0.1",
@@ -13,6 +13,7 @@
     "gen:types": "gulp --color --gulpfile gulpfile.js build_types",
     "copy:types": "yarn copyfiles -u 1 src/__gen__/* src/__gen__/**/* dist",
     "prepare": "husky install",
+    "publish:npm": "yarn build && yarn publish",
     "lint": "eslint . --ext .ts --fix --max-warnings 0",
     "fmt": "prettier --ignore-path .prettierignore --write \"**/*.+(js|ts|json)\"",
     "test": "jest",
@@ -53,6 +54,17 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/madeinventive/inventive-sdk.git"
+    "url": "git+https://github.com/madeinventive/inventive-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/madeinventive/inventive-sdk/issues"
+  },
+  "homepage": "https://github.com/madeinventive/inventive-sdk#readme",
+  "keywords": [
+    "inventive",
+    "sdk"
+  ],
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This PR
1. completes [IA-1128]
2. adds the manual flow to publish to Npmjs, plus
3. a bunch of repo infra stuff for DX, such as:
   * the PR template
   * sections in README on commit convention and steps to manually publish to Npmjs

The released sdk gets published to npmjs.com and can be installed by any C1 to embed Inventive chat into their web app:
![Screen Shot 2023-11-16 at 3 10 32 PM](https://github.com/madeinventive/inventive-sdk/assets/99236958/1fcc3416-beef-4381-8514-a3f9d9fa96e6)


[IA-1128]: https://madeinventive.atlassian.net/browse/IA-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ