### PR TITLE
fix: partially rendered embedded chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@inventive/sdk",
   "description": "SDK library for types, function calls and React components to embed Inventive content in any web app",
   "author": "Inventive X",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/InventiveContent.tsx
+++ b/src/InventiveContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AuthorizedUrlInfo } from './types';
 import { createEmbedTokensMessage } from './utils';
 
@@ -8,37 +8,43 @@ export interface InventiveContentProps {
 
 export const InventiveContent = (props: InventiveContentProps) => {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [embedContentInited, setEmbedContentInited] = useState(false);
 
   const { urlInfo } = props;
 
-  useEffect(() => {
-    // nothing to do if urlInfo is not provided
-    if (!urlInfo) return;
+  const handleEmbedContentReady = useCallback((event: MessageEvent) => {
+    // nothing to do if urlInfo is not provided or embed content is already initialized
+    if (!urlInfo || embedContentInited) return;
 
     const targetOrigin = new URL(urlInfo.url).origin;
-
-    const iframe = iframeRef.current;
-    const postMessageToIframe = () => {
-      if (iframe?.contentWindow) {
-        iframe.contentWindow.postMessage(
-          createEmbedTokensMessage(urlInfo.tokens),
-          targetOrigin,
-        );
-      }
-    };
-
-    // Add event listener to post message when iframe is loaded
-    if (iframe) {
-      iframe.addEventListener('load', postMessageToIframe);
+    if (event.origin !== targetOrigin) {
+      // ignore messages from other origins
+      return;
     }
 
+    const { type } = event.data;
+    if (type !== 'embed_content_ready') {
+      // ignore messages with other types
+      return;
+    }
+
+    const iframe = iframeRef.current;
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.postMessage(
+        createEmbedTokensMessage(urlInfo.tokens),
+        targetOrigin,
+      );
+      setEmbedContentInited(true);
+    }
+  }, [embedContentInited, urlInfo]);
+
+  useEffect(() => {
+    window.addEventListener('message', handleEmbedContentReady);
     // Cleanup the event listener on component unmount
     return () => {
-      if (iframe) {
-        iframe.removeEventListener('load', postMessageToIframe);
-      }
+      window.removeEventListener('message', handleEmbedContentReady);
     };
-  }, [urlInfo]);
+  }, []);
 
   if (!urlInfo) return null;
   return (

--- a/src/InventiveContent.tsx
+++ b/src/InventiveContent.tsx
@@ -44,7 +44,7 @@ export const InventiveContent = (props: InventiveContentProps) => {
     return () => {
       window.removeEventListener('message', handleEmbedContentReady);
     };
-  }, []);
+  }, [handleEmbedContentReady]);
 
   if (!urlInfo) return null;
   return (


### PR DESCRIPTION
# Description
The issue with previously the parent window sent the `embed_tokens` message to the embedded content the moment iframe declares that all the needed resources are loaded is that resources loaded is not the same as the embedded chat is ready to process the `embed_tokens` message. The chat window ended up in the limbo state when the message is sent before the chat is ready.

Rather than sending `embed_tokens` message on `load`, the solution is for the parent window to wait until the embedded content says it is ready (via the `embed_content_ready` message).

The PR updates the `InventiveContent` component to encapsulate the new protocol.

# Fixes / Implements
[IA-1176]

# How Has This Been Tested?
Manual QA, end-to-end with `test-c1-app` locally.

# Checklist
<!--- list of things to check before requesting for review -->
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [X] I have tagged @inventive-eng as one of the reviewers


[IA-1176]: https://madeinventive.atlassian.net/browse/IA-1176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ