### PR TITLE
feat: upgrade InventiveContent component with new handshake

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@inventive/sdk",
   "description": "SDK library for types, function calls and React components to embed Inventive content in any web app",
   "author": "Inventive X",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/InventiveContent.tsx
+++ b/src/InventiveContent.tsx
@@ -34,7 +34,7 @@ export const InventiveContent = ({
       const iframe = iframeRef.current;
       if (iframe?.contentWindow) {
         iframe.contentWindow.postMessage(
-          createEmbedTokensMessage(urlInfo.tokens, hostUrl),
+          createEmbedTokensMessage(urlInfo.tokens, urlInfo.scopeToken, hostUrl),
           targetOrigin
         );
         setEmbedContentInited(true);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,11 +60,13 @@ export const getRESTApiHeaders = (): Record<string, string> => {
 
 export const createEmbedTokensMessage = (
   tokens?: TokensData,
+  scopeToken?: string,
   hostUrl?: string
 ): EmbedTokensMessage => {
   return {
     type: 'embed_tokens',
     tokens,
+    scopeToken,
     hostUrl,
   };
 };


### PR DESCRIPTION
# Description
Sorry, missed one commit in my previous PR - this one is needed so that `InventiveComponent` also handshake with the new `scopeToken`.

# Fixes / Implements
[IA-1269]

# How Has This Been Tested?
Local end-to-end tests with `test-c1-app`

# Checklist
<!--- list of things to check before requesting for review -->
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [X] I have tagged @inventive-eng as one of the reviewers


[IA-1269]: https://madeinventive.atlassian.net/browse/IA-1269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ